### PR TITLE
TypeLoadException for Microsoft.AspNet.Hosting.WebHost

### DIFF
--- a/src/k-http/project.json
+++ b/src/k-http/project.json
@@ -6,13 +6,13 @@
     "projectUrl": "https://github.com/tugberkugurlu/k-http",
     "licenseUrl": "https://raw.githubusercontent.com/tugberkugurlu/k-http/master/LICENSE",
     "dependencies": {
-        "Microsoft.AspNet.Hosting": "1.0.0-beta5-*",
-        "Microsoft.AspNet.Server.WebListener": "1.0.0-beta5-*",
-        "Microsoft.AspNet.StaticFiles": "1.0.0-beta5-*",
-        "Microsoft.Framework.ConfigurationModel": "1.0.0-beta5-*",
-        "Microsoft.Framework.DependencyInjection": "1.0.0-beta5-*",
-        "Microsoft.Framework.Logging.Console": "1.0.0-beta5-*",
-        "Microsoft.Framework.Runtime.Interfaces": "1.0.0-beta5-*"
+        "Microsoft.AspNet.Hosting": "1.0.0-beta5-11672",
+        "Microsoft.AspNet.Server.WebListener": "1.0.0-beta5-12038",
+        "Microsoft.AspNet.StaticFiles": "1.0.0-beta5-11825",
+        "Microsoft.Framework.ConfigurationModel": "1.0.0-beta5-11240",
+        "Microsoft.Framework.DependencyInjection": "1.0.0-beta5-11269",
+        "Microsoft.Framework.Logging.Console": "1.0.0-beta5-11266",
+        "Microsoft.Framework.Runtime.Interfaces": "1.0.0-beta5-11611"
     },
     "commands": {
         "k-http": "run"

--- a/src/k-http/project.json
+++ b/src/k-http/project.json
@@ -1,6 +1,6 @@
 {
     "description": "Command-line HTTP server suitable for testing and local development to host static files.",
-    "version": "0.1.0-beta-002",
+    "version": "0.1.0-beta-003",
     "authors": [ "Tugberk Ugurlu" ],
     "tags": [ "http", "http-server", "static-files-server", "aspnet5" ],
     "projectUrl": "https://github.com/tugberkugurlu/k-http",


### PR DESCRIPTION
I'm recently getting `System.TypeLoadException: Could not load type "Microsoft.AspNet.Hosting.WebHost" from assembly "Microsoft.AspNet.Hosting, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null"` when invoking k-http.

Looks like this is caused by https://github.com/aspnet/Hosting/commit/234bbf82f2329e1ce2092962264ba5d4567d115b

You should probably pin to a specific version until the breaking changes are over.
